### PR TITLE
fix: ensure fetch-depth is set for code checkout in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v2


### PR DESCRIPTION
follow fetch-depth guidance from https://goreleaser.com/ci/actions/#workflow